### PR TITLE
feat: update AWS S3 sync process in workflows

### DIFF
--- a/.github/workflows/aws-prod.yaml
+++ b/.github/workflows/aws-prod.yaml
@@ -46,8 +46,5 @@ jobs:
         run: |
           aws s3 ls --region=ap-northeast-1
           aws s3 ls s3://$S3_BUCKET --region=ap-northeast-1
-          aws s3 rm s3://$S3_BUCKET/ --recursive --region=ap-northeast-1
-          echo "After remove"
-          aws s3 ls s3://$S3_BUCKET --region=ap-northeast-1
-          aws s3 cp ./out s3://$S3_BUCKET/ --recursive --region=ap-northeast-1
+          aws s3 sync ./out s3://$S3_BUCKET/ --delete --region=ap-northeast-1
           aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*' --region=us-east-1

--- a/.github/workflows/aws-test.yaml
+++ b/.github/workflows/aws-test.yaml
@@ -52,8 +52,5 @@ jobs:
         run: |
           aws s3 ls --region=ap-northeast-1
           aws s3 ls s3://$S3_BUCKET --region=ap-northeast-1
-          aws s3 rm s3://$S3_BUCKET/ --recursive --region=ap-northeast-1
-          echo "After remove"
-          aws s3 ls s3://$S3_BUCKET --region=ap-northeast-1
-          aws s3 cp ./out s3://$S3_BUCKET/ --recursive --region=ap-northeast-1
+          aws s3 sync ./out s3://$S3_BUCKET/ --delete --region=ap-northeast-1
           aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths '/*' --region=us-east-1


### PR DESCRIPTION
- Replaced `aws s3 rm` and `aws s3 cp` commands with `aws s3 sync` for more efficient synchronization of local output to S3.
- Ensured that the sync operation deletes files in the S3 bucket that are not present in the local output directory.
- Maintained the cloudfront invalidation command to refresh the cache after deployment.